### PR TITLE
chore: upgrade workflows action versions

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       # Pull the central label manifest from anaverage-enri/.github
       - name: Checkout shared label manifest
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: anaverage-enri/.github
           path: .github-config

--- a/.github/workflows/path-labeler.yml
+++ b/.github/workflows/path-labeler.yml
@@ -31,7 +31,7 @@ jobs:
       # Apply labels
       #
       - name: Apply path labels
-        uses: actions/labeler@v5
+        uses: actions/labeler@v6.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github-config/path-labels.yml

--- a/.github/workflows/path-labeler.yml
+++ b/.github/workflows/path-labeler.yml
@@ -16,13 +16,13 @@ jobs:
       # Checkout target repository
       #
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       #
       # Checkout central .github repository
       #
       - name: Checkout shared label config
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: anaverage-enri/.github
           path: .github-config

--- a/.github/workflows/size-labeler.yml
+++ b/.github/workflows/size-labeler.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Label PR size
         uses: pascalgn/size-label-action@v0.5.5

--- a/.github/workflows/size-labeler.yml
+++ b/.github/workflows/size-labeler.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Label PR size
-        uses: pascalgn/size-label-action@v0.5.5
+        uses: pascalgn/size-label-action@v0.5.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
# Summary

- Updated all `actions/checkout` steps from version `v4` to `v5` in `.github/workflows/label-sync.yml`, `.github/workflows/path-labeler.yml`, and `.github/workflows/size-labeler.yml`.
- Upgraded `actions/labeler` from `v5` to `v6.1.0` in `.github/workflows/path-labeler.yml`.
- Updated `pascalgn/size-label-action` from `v0.5.5` to `v0.5.7` in `.github/workflows/size-labeler.yml`.