### PR TITLE
fix: provide permissions for workflow scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ name: Sync Repository Label Definitions
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   sync:
     uses: anaverage-enri/.github/.github/workflows/label-sync.yml@main


### PR DESCRIPTION
# Summary
This pull request adds permissions configuration to the `Sync Repository Label Definitions` workflow to ensure it can read repository contents and write to issues.

- **Workflow permissions update:**
  * Added `contents: read` and `issues: write` permissions to the workflow configuration in `README.md` to allow the label sync job to function correctly.