### PR TITLE
fix: prevent empty delete-other-labels value in reusable label-sync

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -37,5 +37,7 @@ jobs:
         uses: EndBug/label-sync@v2
         with:
           config-file: .github-config/.github-labels.yml
-          # Using context fallback ensures it works regardless of how it was triggered
-          delete-other-labels: ${{ inputs.delete-other-labels || github.event.inputs.delete-other-labels }}
+          # The `inputs` context is populated for both workflow_call and workflow_dispatch,
+          # so no github.event.inputs fallback is needed. Avoid `||`: since `false` is falsy,
+          # `false || <empty>` would resolve to an empty string, which the action rejects.
+          delete-other-labels: ${{ inputs.delete-other-labels }}


### PR DESCRIPTION
## Problem

Callers of the reusable `label-sync.yml` workflow hit:

> ✗ The only values you can use for the `delete-other-labels` option are `true` and `false`

## Root cause

The step forwarded the input with a fallback expression:

```yaml
delete-other-labels: ${{ inputs.delete-other-labels || github.event.inputs.delete-other-labels }}
```

In GitHub Actions expressions, `a || b` returns `b` whenever `a` is falsy — and `false` is falsy. So with the default (or an explicit) `false`, this became `false || github.event.inputs.delete-other-labels`. On a `workflow_call` trigger there is no `github.event.inputs`, so it resolved to an **empty string**, which `EndBug/label-sync` rejects.

## Fix

Use `inputs.delete-other-labels` directly. The `inputs` context is populated for **both** `workflow_call` and `workflow_dispatch`, so the `github.event.inputs` fallback was both redundant and the source of the bug.