### PR TITLE
docs: document label configuration files in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A fallback `.github` repository that applies community health files and shared w
 │   └── feature_request.yml
 ├── CODE_OF_CONDUCT.md
 ├── CODEOWNERS
+├── .github-labels.yml
 ├── path-labels.yml
 ├── LICENSE
 ├── PULL_REQUEST_TEMPLATE.md
@@ -31,7 +32,7 @@ A fallback `.github` repository that applies community health files and shared w
 |---|---|
 | `path-labeler.yml` | Labels PRs by changed file paths |
 | `size-labeler.yml` | Labels PRs by size (XS–XXL) |
-| `label-sync.yml` | Syncs repository label definitions from the central manifest |
+| `label-sync.yml` | Syncs repository label definitions from the central `.github-labels.yml` manifest |
 
 ## Usage in consumer repos
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ A fallback `.github` repository that applies community health files and shared w
 | `size-labeler.yml` | Labels PRs by size (XS–XXL) |
 | `label-sync.yml` | Syncs repository label definitions from the central `.github-labels.yml` manifest |
 
+## Label configuration
+
+Two files at the repo root drive labeling, and both are read from this repo by the
+reusable workflows:
+
+| File | Purpose | Consumed by |
+|---|---|---|
+| `.github-labels.yml` | The canonical label set — each label's name, color, and description. | `label-sync.yml` |
+| `path-labels.yml` | Maps changed-file globs to labels (e.g. `*.md` → `docs`). | `path-labeler.yml` |
+
 ## Usage in consumer repos
 
 Add thin callers in each consumer repo under `.github/workflows/`.


### PR DESCRIPTION
## Summary

The README's Contents tree omitted `.github-labels.yml` — the central label manifest that `label-sync.yml` reads (`config-file: .github-config/.github-labels.yml`). The label-sync row referenced "the central manifest" without ever naming or listing the file, so a reader couldn't tell where labels are defined.

This PR makes the two label-config files discoverable and explains what each does:

- **`docs(readme): list .github-labels.yml manifest`** — adds the manifest to the Contents tree and names it in the Workflows table row.
- **`docs(readme): explain label configuration files`** — adds a "Label configuration" section distinguishing `.github-labels.yml` (canonical label set) from `path-labels.yml` (path→label rules), and notes which reusable workflow consumes each.

Note: the recent functional commits (label-sync `delete-other-labels` fix, workflow-scaffolding permissions, action version bumps) were already reflected in the README or are internal to the reusable workflows, so they needed no doc changes.

## Test plan

Docs-only — no CI to run.

- [x] Contents tree matches the tracked files (`find . -type f`), ignoring `.DS_Store`/`.gitignore`.
- [x] Every file named in prose (`.github-labels.yml`, `path-labels.yml`) appears in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)